### PR TITLE
Fix to work with either-3.0.2

### DIFF
--- a/Control/Error.hs
+++ b/Control/Error.hs
@@ -23,7 +23,7 @@ module Control.Error (
 import Control.Error.Script
 import Control.Error.Safe
 import Control.Error.Util
-import Control.Monad.Trans.Either
+import Control.Monad.Trans.Either hiding (right)
 import Control.Monad.Trans.Maybe
 import Data.Either
 import Data.EitherR

--- a/Data/EitherR.hs
+++ b/Data/EitherR.hs
@@ -50,7 +50,7 @@ module Data.EitherR (
 import Control.Applicative
 import Control.Monad
 import Control.Monad.Trans.Class
-import Control.Monad.Trans.Either
+import Control.Monad.Trans.Either hiding (right)
 
 {-|
     If \"@Either e r@\" is the error monad, then \"@EitherR r e@\" is the
@@ -125,10 +125,6 @@ right = EitherRT . return
 -- | Complete error handling, returning a result
 succeedT :: (Monad m) => r -> EitherRT r m e
 succeedT = right
-
--- | Synonym for 'throwT'
-left :: (Monad m) => e -> EitherT e m r
-left = EitherT . return . Left
 
 -- | 'throwT' in the error monad corresponds to 'return' in the success monad
 throwT :: (Monad m) => e -> EitherT e m r

--- a/errors.cabal
+++ b/errors.cabal
@@ -23,7 +23,7 @@ Source-Repository head
     Location: https://github.com/Gabriel439/Haskell-Errors-Library
 
 Library
-    Build-Depends: base >= 4 && < 5, either, safe, transformers
+    Build-Depends: base >= 4 && < 5, either >= 3.0.2, safe, transformers
     Exposed-Modules:
         Control.Error,
         Control.Error.Script,


### PR DESCRIPTION
either-3.0.2 now exports 'right' and 'left' definitions which conflict
with errors. The definition of left is identical to what is already in
errors, so I've removed that. The definition of right looks like it
conflicts, so I'm just hiding it for now.
