### PR TITLE
Use const instead of (\_ ->)

### DIFF
--- a/Control/Error/Safe.hs
+++ b/Control/Error/Safe.hs
@@ -73,7 +73,7 @@ assertMay = assertZ
 
 -- | A 'fromRight' that fails in the 'Maybe' monad
 rightMay :: Either e a -> Maybe a
-rightMay = either (\_ -> Nothing) Just
+rightMay = either (const Nothing) Just
 
 -- | A 'tail' that fails in the 'Either' monad
 tailErr :: e -> [a] -> Either e [a]
@@ -237,4 +237,4 @@ justZ = maybe mzero return
 
 -- | A 'fromRight' that fails using 'mzero'
 rightZ :: (MonadPlus m) => Either e a -> m a
-rightZ = either (\_ -> mzero) return
+rightZ = either (const mzero) return

--- a/Control/Error/Util.hs
+++ b/Control/Error/Util.hs
@@ -39,7 +39,7 @@ import Data.EitherR (fmapL, fmapLT)
 -}
 -- | Suppress the 'Left' value of an 'Either'
 hush :: Either a b -> Maybe b
-hush = either (\_ -> Nothing) Just
+hush = either (const Nothing) Just
 
 -- | Suppress the 'Left' value of an 'EitherT'
 hushT :: (Monad m) => EitherT a m b -> MaybeT m b
@@ -59,11 +59,11 @@ hoistMaybe = MaybeT . return
 
 -- | Returns whether argument is a 'Left'
 isLeft :: Either a b -> Bool
-isLeft = either (\_ -> True) (\_ -> False)
+isLeft = either (const True) (const False)
 
 -- | Returns whether argument is a 'Right'
 isRight :: Either a b -> Bool
-isRight = either (\_ -> False) (\_ -> True)
+isRight = either (const False) (const True)
 
 -- | 'fmap' specialized to 'Either', given a name symmetric to 'fmapL'
 fmapR :: (a -> b) -> Either l a -> Either l b


### PR DESCRIPTION
Hi Gabriel,

When reading your library I noticed a few `(\_ -> Nothing)` and `(_ -> mzero)` sprinkled around.  Any reason for not using the constant function?

Thanks!
