### PR TITLE
Add Control.Error.Util.bool

### DIFF
--- a/Control/Error/Util.hs
+++ b/Control/Error/Util.hs
@@ -13,6 +13,9 @@ module Control.Error.Util (
     failWith,
     failWithM,
 
+    -- * Bool
+    bool,
+
     -- * MaybeT
     maybeT,
     just,
@@ -34,7 +37,7 @@ module Control.Error.Util (
 
     -- * Exceptions
     tryIO,
-    syncIO 
+    syncIO
     ) where
 
 import Control.Applicative (Applicative, pure, (<$>))
@@ -104,6 +107,14 @@ failWith e a = a ?? e
 -}
 failWithM :: Applicative m => e -> m (Maybe a) -> EitherT e m a
 failWithM e a = a !? e
+
+{- | Case analysis for the 'Bool' type.
+
+   > bool a b c == if c then b else a
+-}
+bool :: a -> a -> Bool -> a
+bool a b = \c -> if c then b else a
+{-# INLINABLE bool #-}
 
 {-| Case analysis for 'MaybeT'
 


### PR DESCRIPTION
This very same function will be present in `Data.Bool.bool` in `base>=4.7.0`, but for now, it's not available in `base` so I propose its addition here.

I considered adding a CPP pragma checking for the `base` version and either defining or re-exporting `Data.Bool.bool` based on that, but it seems too cumbersome for this simple purpose.
