### PR TITLE
Initial conversion to ExceptT.

### DIFF
--- a/Control/Error.hs
+++ b/Control/Error.hs
@@ -15,7 +15,7 @@
     * "Control.Error.Util": Utility functions and conversions between common
       error-handling types
 
-    * @Control.Monad.Trans.Either@: The 'EitherT' monad transformer
+    * @Control.Monad.Trans.Except@: The 'ExceptT' monad transformer
 
     * @Control.Monad.Trans.Maybe@: The 'MaybeT' monad transformer
 
@@ -36,7 +36,7 @@ module Control.Error (
     module Control.Error.Safe,
     module Control.Error.Script,
     module Control.Error.Util,
-    module Control.Monad.Trans.Either,
+    module Control.Monad.Trans.Except,
     module Control.Monad.Trans.Maybe,
     module Data.Either,
     module Data.EitherR,
@@ -47,15 +47,13 @@ module Control.Error (
 import Control.Error.Safe
 import Control.Error.Script
 import Control.Error.Util
-import Control.Monad.Trans.Either (
-    EitherT(EitherT),
-    runEitherT,
-    eitherT,
-    bimapEitherT,
-    mapEitherT,
-    hoistEither,
-    left,
-    right )
+import Control.Monad.Trans.Except (
+    ExceptT(ExceptT),
+    runExceptT,
+    throwE,
+    catchE,
+    mapExceptT,
+    withExceptT )
 import Control.Monad.Trans.Maybe (
     MaybeT(MaybeT),
     runMaybeT,

--- a/Control/Error/Safe.hs
+++ b/Control/Error/Safe.hs
@@ -1,9 +1,9 @@
 {-| This module extends the @safe@ library's functions with corresponding
-    versions compatible with 'Either' and 'EitherT', and also provides a few
+    versions compatible with 'Either' and 'ExceptT', and also provides a few
     'Maybe'-compatible functions missing from @safe@.
 
     I suffix the 'Either'-compatible functions with @Err@ and prefix the
-    'EitherT'-compatible functions with @try@.
+    'ExceptT'-compatible functions with @try@.
 
     Note that this library re-exports the 'Maybe' compatible functions from
     @safe@ in the "Control.Error" module, so they are not provided here.
@@ -15,7 +15,7 @@
 
     * Most parsers
 
-    * 'EitherT' (if the left value is a 'Monoid')
+    * 'ExceptT' (if the left value is a 'Monoid')
 -}
 
 module Control.Error.Safe (
@@ -38,7 +38,7 @@ module Control.Error.Safe (
     assertErr,
     justErr,
 
-    -- * EitherT-compatible functions
+    -- * ExceptT-compatible functions
     tryTail,
     tryInit,
     tryHead,
@@ -71,9 +71,9 @@ module Control.Error.Safe (
     rightZ
     ) where
 
-import Control.Error.Util (note)
+import Control.Error.Util (note, hoistEither)
 import Control.Monad (MonadPlus(mzero))
-import Control.Monad.Trans.Either (EitherT, hoistEither)
+import Control.Monad.Trans.Except (ExceptT)
 import qualified Safe as S
 
 -- | An assertion that fails in the 'Maybe' monad
@@ -136,60 +136,60 @@ assertErr e p = if p then Right () else Left e
 justErr :: e -> Maybe a -> Either e a
 justErr e = maybe (Left e) Right
 
--- | A 'tail' that fails in the 'EitherT' monad
-tryTail :: (Monad m) => e -> [a] -> EitherT e m [a]
+-- | A 'tail' that fails in the 'ExceptT' monad
+tryTail :: (Monad m) => e -> [a] -> ExceptT e m [a]
 tryTail e xs = hoistEither $ tailErr e xs
 
--- | An 'init' that fails in the 'EitherT' monad
-tryInit :: (Monad m) => e -> [a] -> EitherT e m [a]
+-- | An 'init' that fails in the 'ExceptT' monad
+tryInit :: (Monad m) => e -> [a] -> ExceptT e m [a]
 tryInit e xs = hoistEither $ initErr e xs
 
--- | A 'head' that fails in the 'EitherT' monad
-tryHead :: (Monad m) => e -> [a] -> EitherT e m a
+-- | A 'head' that fails in the 'ExceptT' monad
+tryHead :: (Monad m) => e -> [a] -> ExceptT e m a
 tryHead e xs = hoistEither $ headErr e xs
 
--- | A 'last' that fails in the 'EitherT' monad
-tryLast :: (Monad m) => e -> [a] -> EitherT e m a
+-- | A 'last' that fails in the 'ExceptT' monad
+tryLast :: (Monad m) => e -> [a] -> ExceptT e m a
 tryLast e xs = hoistEither $ lastErr e xs
 
--- | A 'minimum' that fails in the 'EitherT' monad
-tryMinimum :: (Monad m, Ord a) => e -> [a] -> EitherT e m a
+-- | A 'minimum' that fails in the 'ExceptT' monad
+tryMinimum :: (Monad m, Ord a) => e -> [a] -> ExceptT e m a
 tryMinimum e xs = hoistEither $ maximumErr e xs
 
--- | A 'maximum' that fails in the 'EitherT' monad
-tryMaximum :: (Monad m, Ord a) => e -> [a] -> EitherT e m a
+-- | A 'maximum' that fails in the 'ExceptT' monad
+tryMaximum :: (Monad m, Ord a) => e -> [a] -> ExceptT e m a
 tryMaximum e xs = hoistEither $ maximumErr e xs
 
--- | A 'foldr1' that fails in the 'EitherT' monad
-tryFoldr1 :: (Monad m) => e -> (a -> a -> a) -> [a] -> EitherT e m a
+-- | A 'foldr1' that fails in the 'ExceptT' monad
+tryFoldr1 :: (Monad m) => e -> (a -> a -> a) -> [a] -> ExceptT e m a
 tryFoldr1 e step xs = hoistEither $ foldr1Err e step xs
 
--- | A 'foldl1' that fails in the 'EitherT' monad
-tryFoldl1 :: (Monad m) => e -> (a -> a -> a) -> [a] -> EitherT e m a
+-- | A 'foldl1' that fails in the 'ExceptT' monad
+tryFoldl1 :: (Monad m) => e -> (a -> a -> a) -> [a] -> ExceptT e m a
 tryFoldl1 e step xs = hoistEither $ foldl1Err e step xs
 
--- | A 'foldl1'' that fails in the 'EitherT' monad
-tryFoldl1' :: (Monad m) => e -> (a -> a -> a) -> [a] -> EitherT e m a
+-- | A 'foldl1'' that fails in the 'ExceptT' monad
+tryFoldl1' :: (Monad m) => e -> (a -> a -> a) -> [a] -> ExceptT e m a
 tryFoldl1' e step xs = hoistEither $ foldl1Err' e step xs
 
--- | A ('!!') that fails in the 'EitherT' monad
-tryAt :: (Monad m) => e -> [a] -> Int -> EitherT e m a
+-- | A ('!!') that fails in the 'ExceptT' monad
+tryAt :: (Monad m) => e -> [a] -> Int -> ExceptT e m a
 tryAt e xs n = hoistEither $ atErr e xs n
 
--- | A 'read' that fails in the 'EitherT' monad
-tryRead :: (Monad m, Read a) => e -> String -> EitherT e m a
+-- | A 'read' that fails in the 'ExceptT' monad
+tryRead :: (Monad m, Read a) => e -> String -> ExceptT e m a
 tryRead e str = hoistEither $ readErr e str
 
--- | An assertion that fails in the 'EitherT' monad
-tryAssert :: (Monad m) => e -> Bool -> EitherT e m ()
+-- | An assertion that fails in the 'ExceptT' monad
+tryAssert :: (Monad m) => e -> Bool -> ExceptT e m ()
 tryAssert e p = hoistEither $ assertErr e p
 
--- | A 'fromJust' that fails in the 'EitherT' monad
-tryJust :: (Monad m) => e -> Maybe a -> EitherT e m a
+-- | A 'fromJust' that fails in the 'ExceptT' monad
+tryJust :: (Monad m) => e -> Maybe a -> ExceptT e m a
 tryJust e m = hoistEither $ justErr e m
 
--- | A 'fromRight' that fails in the 'EitherT' monad
-tryRight :: (Monad m) => Either e a -> EitherT e m a
+-- | A 'fromRight' that fails in the 'ExceptT' monad
+tryRight :: (Monad m) => Either e a -> ExceptT e m a
 tryRight = hoistEither
 
 -- | A 'tail' that fails using 'mzero'

--- a/Control/Error/Script.hs
+++ b/Control/Error/Script.hs
@@ -1,6 +1,6 @@
 {-|
     Use this module if you like to write simple scripts with 'String'-based
-    errors, but you prefer to use 'EitherT' to handle errors rather than
+    errors, but you prefer to use 'ExceptT' to handle errors rather than
     @Control.Exception@.
 
 > import Control.Error
@@ -21,7 +21,7 @@ module Control.Error.Script (
 import Control.Exception (try, SomeException)
 import Control.Monad (liftM)
 import Control.Monad.IO.Class (MonadIO(liftIO))
-import Control.Monad.Trans.Either (EitherT(EitherT, runEitherT))
+import Control.Monad.Trans.Except (ExceptT(ExceptT), runExceptT)
 import Control.Error.Util (errLn)
 import Data.EitherR (fmapL)
 import System.Environment (getProgName)
@@ -32,7 +32,7 @@ import Control.Monad.Trans.Class (lift)
 import System.IO (stderr)
 
 -- | An 'IO' action that can fail with a 'String' error message
-type Script = EitherT String IO
+type Script = ExceptT String IO
 
 {-| Runs the 'Script' monad
 
@@ -40,7 +40,7 @@ type Script = EitherT String IO
 -}
 runScript :: Script a -> IO a
 runScript s = do
-    e <- runEitherT s
+    e <- runExceptT s
     case e of
         Left  e -> do
             errLn =<< liftM (++ ": " ++ e) getProgName
@@ -52,8 +52,8 @@ runScript s = do
 
     Note that 'scriptIO' is compatible with the 'Script' monad.
 -}
-scriptIO :: (MonadIO m) => IO a -> EitherT String m a
-scriptIO = EitherT
+scriptIO :: (MonadIO m) => IO a -> ExceptT String m a
+scriptIO = ExceptT
          . liftIO
          . liftM (fmapL show)
          . (try :: IO a -> IO (Either SomeException a))

--- a/Control/Error/Util.hs
+++ b/Control/Error/Util.hs
@@ -62,12 +62,14 @@ import Data.Maybe (fromMaybe)
 import System.Exit (ExitCode)
 import System.IO (hPutStr, hPutStrLn, stderr)
 
+-- | Fold an 'ExceptT' by providing one continuation for each constructor
 exceptT :: Monad m => (a -> m c) -> (b -> m c) -> ExceptT a m b -> m c
 exceptT f g (ExceptT m) = m >>= \z -> case z of
     Left  a -> f a
     Right b -> g b
 {-# INLINEABLE exceptT #-}
 
+-- | Transform the left and right value
 bimapExceptT :: Functor m => (e -> f) -> (a -> b) -> ExceptT e m a -> ExceptT f m b
 bimapExceptT f g (ExceptT m) = ExceptT (fmap h m)
   where
@@ -75,6 +77,7 @@ bimapExceptT f g (ExceptT m) = ExceptT (fmap h m)
     h (Right a) = Right (g a)
 {-# INLINEABLE bimapExceptT #-}
 
+-- | Upgrade an 'Either' to an 'ExceptT'
 hoistEither :: Monad m => Either e a -> ExceptT e m a
 hoistEither = ExceptT . return
 {-# INLINEABLE hoistEither #-}

--- a/errors.cabal
+++ b/errors.cabal
@@ -23,9 +23,8 @@ Source-Repository head
 Library
     Build-Depends:
         base         >= 4     && < 5  ,
-        either       >= 3.1   && < 5  ,
         safe         >= 0.3.3 && < 0.4,
-        transformers >= 0.2   && < 0.5
+        transformers >= 0.4   && < 0.5
     Exposed-Modules:
         Control.Error,
         Control.Error.Safe,


### PR DESCRIPTION
Supporting issue #32.

I provisionally renamed `throwE`, `catchE`, `handleE`, and `flipE` to `throwEither`, `catchEither`, `handleEither`, and `flipEither` because `throwE` and `catchE` exist in `Control.Monad.Trans.Except`. I also removed `throwT` and `catchT` because of that and instead renamed `handleT` to `handleE`.