### PR TITLE
Better definition of async exceptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ before_cache:
 
 matrix:
   include:
-    - env: CABALVER=1.16 GHCVER=7.6.3
-      compiler: ": #GHC 7.6.3"
-      addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3], sources: [hvr-ghc]}}
     - env: CABALVER=1.18 GHCVER=7.8.4
       compiler: ": #GHC 7.8.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}

--- a/errors.cabal
+++ b/errors.cabal
@@ -2,7 +2,7 @@ Name: errors
 Version: 2.2.5
 Cabal-Version: >=1.8.0.2
 Build-Type: Simple
-Tested-With: GHC == 7.6.3, GHC == 7.8.4, GHC == 7.10.2, GHC == 8.0.1
+Tested-With: GHC == 7.8.4, GHC == 7.10.2, GHC == 8.0.1
 License: BSD3
 License-File: LICENSE
 Copyright: 2012, 2013 Gabriel Gonzalez
@@ -24,12 +24,11 @@ Source-Repository head
 
 Library
     Build-Depends:
-        base                >= 4     && < 5   ,
+        base                >= 4.7   && < 5   ,
         exceptions          >= 0.6   && < 0.11,
         text                            < 1.3 ,
         transformers        >= 0.2   && < 0.6 ,
-        transformers-compat >= 0.4   && < 0.7 ,
-        unexceptionalio     >= 0.3   && < 0.4
+        transformers-compat >= 0.4   && < 0.7
     if impl(ghc <= 7.6.3)
         Build-Depends:
             safe            >= 0.3.3 && < 0.3.10


### PR DESCRIPTION
syncIO previously relied upon the unexceptionalio package, which does
not use the standard definition from base of an asynchronous exception.
This brings errors in line with other libraries in the ecosystem for
recovering from all exceptions.