### PR TITLE
Update errors.cabal to support text-2.1

### DIFF
--- a/errors.cabal
+++ b/errors.cabal
@@ -26,7 +26,7 @@ Library
     Build-Depends:
         base                >= 4.7   && < 5   ,
         exceptions          >= 0.6   && < 0.11,
-        text                            < 2.1 ,
+        text                            < 2.2 ,
         transformers        >= 0.2   && < 0.7 ,
         transformers-compat >= 0.4   && < 0.8
     if impl(ghc <= 7.6.3)


### PR DESCRIPTION
This library doesn't access the internals of the `Text` type, so this should be fine.